### PR TITLE
chore: add github-actions Dependabot so action versions auto-update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds github-actions to Dependabot so action versions (e.g. actions/checkout node20 -> node24) auto-update going forward, grouped into one PR per repo.